### PR TITLE
Change instantdata userconfig

### DIFF
--- a/pkgs/instantData/default.nix
+++ b/pkgs/instantData/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     owner = "ppenguin";
     repo = "instantData";
     rev = "9333d102c20f17d5f191880727f7888c5907cbcd";
-    sha256 = "sha256:1jb43ajd140m3mdqzs7vyyd7634j1zl0wdni48scs5mvgb7kgz51";
+    sha256 = "sha256:13xv5s8sr6vrlxs60w3c8x8s16wbbmvqywh44q6j79lq5mgrj4b5";
     name = "instantOS_instantData";
   };
 

--- a/pkgs/instantData/default.nix
+++ b/pkgs/instantData/default.nix
@@ -25,8 +25,9 @@ stdenv.mkDerivation {
     owner = "ppenguin";
     repo = "instantData";
     # rev = "ade1148cd26c272cb569f9a4c10337f5a4e91f29";
+    ref = "add-user-config-capability";
     rev = "bba7c8e13eec3791aa65e7bbc41c69928a26d842";
-    sha256 = "sha256:16cp3jxggpkf3nc2vylykgrnlaa1vfbq0hhpwpjk9x5kwc87ng79";
+    sha256 = "sha256:06x6fy1al20m37sa32i6kxczjws39zfg1xrwa4n0vfyrq1mj734l";
     name = "instantOS_instantData";
   };
 

--- a/pkgs/instantData/default.nix
+++ b/pkgs/instantData/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     owner = "ppenguin";
     repo = "instantData";
     # rev = "ade1148cd26c272cb569f9a4c10337f5a4e91f29";
-    rev = "e707dbdd7c99e948a9ab7e1c5b82496168f3d642";
+    rev = "bba7c8e13eec3791aa65e7bbc41c69928a26d842";
     sha256 = "sha256:16cp3jxggpkf3nc2vylykgrnlaa1vfbq0hhpwpjk9x5kwc87ng79";
     name = "instantOS_instantData";
   };

--- a/pkgs/instantData/default.nix
+++ b/pkgs/instantData/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     owner = "ppenguin";
     repo = "instantData";
     rev = "8f86684d38bbe2ffb36cf3c597b592c344dc5b52";
-    sha256 = "sha256:0h3fdfp4917vv4a4grpc7ymr9kgzzq792b6v9kfhzxgb8b1frvv4";
+    sha256 = "sha256:1kiwf4blcfhh4dz9jwas3jvqv8bc33id446a8zv1813jjwmj6nvw";
     name = "instantOS_instantData";
   };
 

--- a/pkgs/instantData/default.nix
+++ b/pkgs/instantData/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     repo = "instantData";
     # rev = "ade1148cd26c272cb569f9a4c10337f5a4e91f29";
     rev = "e707dbdd7c99e948a9ab7e1c5b82496168f3d642";
-    sha256 = "0amlr04fk7r3azbq01lflf9izlzaaijdm19lcndi9bmfp8yci7xr";
+    sha256 = "sha256:16cp3jxggpkf3nc2vylykgrnlaa1vfbq0hhpwpjk9x5kwc87ng79";
     name = "instantOS_instantData";
   };
 

--- a/pkgs/instantData/default.nix
+++ b/pkgs/instantData/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation {
     # owner = "SCOTT-HAMILTON";
     owner = "ppenguin";
     repo = "instantData";
-    rev = "9333d102c20f17d5f191880727f7888c5907cbcd";
-    sha256 = "sha256:13xv5s8sr6vrlxs60w3c8x8s16wbbmvqywh44q6j79lq5mgrj4b5";
+    rev = "8f86684d38bbe2ffb36cf3c597b592c344dc5b52";
+    sha256 = "sha256:0h3fdfp4917vv4a4grpc7ymr9kgzzq792b6v9kfhzxgb8b1frvv4";
     name = "instantOS_instantData";
   };
 

--- a/pkgs/instantData/default.nix
+++ b/pkgs/instantData/default.nix
@@ -21,10 +21,12 @@ stdenv.mkDerivation {
   version = "unstable";
 
   src = fetchFromGitHub {
-    owner = "SCOTT-HAMILTON";
+    # owner = "SCOTT-HAMILTON";
+    owner = "ppenguin";
     repo = "instantData";
-    rev = "ade1148cd26c272cb569f9a4c10337f5a4e91f29";
-    sha256 = "1207ihwxss7v3wz4xcvg21p10a8yz1r9phzb4n43138jpaynziqx";
+    # rev = "ade1148cd26c272cb569f9a4c10337f5a4e91f29";
+    rev = "e707dbdd7c99e948a9ab7e1c5b82496168f3d642";
+    sha256 = "0amlr04fk7r3azbq01lflf9izlzaaijdm19lcndi9bmfp8yci7xr";
     name = "instantOS_instantData";
   };
 
@@ -67,7 +69,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "instantOS Data";
     license = licenses.mit;
-    homepage = "https://github.com/instantOS/IinstantData";
+    homepage = "https://github.com/SCOTT-HAMILTON/InstantData";
     maintainers = [ "Scott Hamilton <sgn.hamilton+nixpkgs@protonmail.com>" ];
     platforms = platforms.linux;
   };

--- a/pkgs/instantData/default.nix
+++ b/pkgs/instantData/default.nix
@@ -24,10 +24,8 @@ stdenv.mkDerivation {
     # owner = "SCOTT-HAMILTON";
     owner = "ppenguin";
     repo = "instantData";
-    # rev = "ade1148cd26c272cb569f9a4c10337f5a4e91f29";
-    ref = "add-user-config-capability";
-    rev = "bba7c8e13eec3791aa65e7bbc41c69928a26d842";
-    sha256 = "sha256:06x6fy1al20m37sa32i6kxczjws39zfg1xrwa4n0vfyrq1mj734l";
+    rev = "9333d102c20f17d5f191880727f7888c5907cbcd";
+    sha256 = "sha256:1jb43ajd140m3mdqzs7vyyd7634j1zl0wdni48scs5mvgb7kgz51";
     name = "instantOS_instantData";
   };
 

--- a/pkgs/instantUtils/default.nix
+++ b/pkgs/instantUtils/default.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation rec {
     substituteInPlace programs/appmenu \
       --replace "#!/usr/bin/dash" "#!/bin/sh" \
       --replace "/usr/share/instantdotfiles/rofi/appmenu.rasi" "tmp_placeholder" \
-      --replace "tmp_placeholder" "\$(instantdata -d)/share/instantdotfiles/rofi/appmenu.rasi"
+      --replace "tmp_placeholder" "\$(instantdata -uc)/rofi/appmenu.rasi"
     substituteInPlace autostart.sh \
       --replace /usr/bin/instantstatus "$out/bin/instantstatus" \
       --replace /usr/share/instantutils "$out/share/instantutils" \

--- a/pkgs/instantUtils/default.nix
+++ b/pkgs/instantUtils/default.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation rec {
     substituteInPlace programs/appmenu \
       --replace "#!/usr/bin/dash" "#!/bin/sh" \
       --replace "/usr/share/instantdotfiles/rofi/appmenu.rasi" "tmp_placeholder" \
-      --replace "tmp_placeholder" "\$(instantdata -uc)/rofi/appmenu.rasi"
+      --replace "tmp_placeholder" "\$(instantdata --get-userconfig-dir=rofi)/appmenu.rasi"
     substituteInPlace autostart.sh \
       --replace /usr/bin/instantstatus "$out/bin/instantstatus" \
       --replace /usr/share/instantutils "$out/share/instantutils" \


### PR DESCRIPTION
Changed to a fork of `instantdata` which offers the option `--get-userconfig-dir=<confdir>` to enable to use personal overrides for files normally only obtained from `...-instantDotfiles-unstable/share/instantdotfiles/<confdir>`.

Added one use case that overrides the `appmenu` config to `~/.config/rofi` if available.